### PR TITLE
feat(fe): handle runners unavailability

### DIFF
--- a/frontend/src/components/actors/actor-filters-context.tsx
+++ b/frontend/src/components/actors/actor-filters-context.tsx
@@ -1,22 +1,14 @@
 import { faHashtag, faKey } from "@rivet-gg/icons";
-import { useQuery } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
-import { CommandGroup, CommandItem } from "cmdk";
 import { createContext, useContext } from "react";
-import { cn } from "../lib/utils";
-import { Checkbox } from "../ui/checkbox";
 import {
 	createFiltersPicker,
 	createFiltersRemover,
 	createFiltersSchema,
 	type FilterDefinitions,
 	FilterOp,
-	type OptionsProviderProps,
+	type PickFiltersOptions,
 } from "../ui/filters";
-import { ActorRegion } from "./actor-region";
-import { ActorStatus } from "./actor-status";
-import { useManager } from "./manager-context";
-import type { ActorStatus as ActorStatusType } from "./queries";
 
 export const ACTORS_FILTERS_DEFINITIONS = {
 	id: {
@@ -47,6 +39,13 @@ export const ACTORS_FILTERS_DEFINITIONS = {
 		label: "Show IDs",
 		category: "display",
 		ephemeral: true,
+	},
+	wakeOnSelect: {
+		type: "boolean",
+		label: "Auto-wake Actors on select",
+		category: "display",
+		ephemeral: true,
+		defaultValue: ["1"],
 	},
 	// tags: {
 	// 	type: "select",
@@ -143,3 +142,11 @@ export const useFilters = (
 		select: (state) => fn(pick(state)),
 	});
 };
+
+export function useFiltersValue(opts: PickFiltersOptions = {}) {
+	const { pick } = useActorsFilters();
+	return useSearch({
+		from: "/_layout",
+		select: (state) => pick(state, opts),
+	});
+}

--- a/frontend/src/components/actors/actor-queries-context.tsx
+++ b/frontend/src/components/actors/actor-queries-context.tsx
@@ -208,6 +208,44 @@ export const defaultActorContext = {
 			},
 		};
 	},
+
+	actorWakeUpMutationOptions(actorId: ActorId) {
+		return {
+			mutationKey: ["actor", actorId, "wake-up"],
+			mutationFn: async () => {
+				const client = this.createActorInspector(actorId);
+				try {
+					await client.ping.$get();
+					return true;
+				} catch {
+					return false;
+				}
+			},
+		};
+	},
+
+	actorAutoWakeUpQueryOptions(
+		actorId: ActorId,
+		{ enabled }: { enabled?: boolean } = {},
+	) {
+		return queryOptions({
+			enabled,
+			refetchInterval: 1000,
+			staleTime: 0,
+			gcTime: 0,
+			queryKey: ["actor", actorId, "auto-wake-up"],
+			queryFn: async ({ queryKey: [, actorId] }) => {
+				const client = this.createActorInspector(actorId);
+				try {
+					await client.ping.$get();
+					return true;
+				} catch {
+					return false;
+				}
+			},
+			retry: false,
+		});
+	},
 };
 
 export type ActorContext = typeof defaultActorContext;

--- a/frontend/src/components/actors/actor-state-tab.tsx
+++ b/frontend/src/components/actors/actor-state-tab.tsx
@@ -5,7 +5,6 @@ import { Button } from "../ui/button";
 import { ActorEditableState } from "./actor-editable-state";
 import { useActor } from "./actor-queries-context";
 import { useActorsView } from "./actors-view-context-provider";
-import { useManager } from "./manager-context";
 import type { ActorId } from "./queries";
 
 interface ActorStateTabProps {
@@ -13,10 +12,6 @@ interface ActorStateTabProps {
 }
 
 export function ActorStateTab({ actorId }: ActorStateTabProps) {
-	const { data: destroyedAt } = useQuery(
-		useManager().actorDestroyedAtQueryOptions(actorId),
-	);
-
 	const { links } = useActorsView();
 
 	const actorQueries = useActor();
@@ -24,13 +19,7 @@ export function ActorStateTab({ actorId }: ActorStateTabProps) {
 		data: state,
 		isError,
 		isLoading,
-	} = useQuery(
-		actorQueries.actorStateQueryOptions(actorId, { enabled: !destroyedAt }),
-	);
-
-	if (destroyedAt) {
-		return <Info>State Preview is unavailable for inactive Actors.</Info>;
-	}
+	} = useQuery(actorQueries.actorStateQueryOptions(actorId));
 
 	if (isError) {
 		return (
@@ -69,7 +58,7 @@ export function ActorStateTab({ actorId }: ActorStateTabProps) {
 
 export function Info({ children }: PropsWithChildren) {
 	return (
-		<div className="flex-1 flex flex-col gap-2 items-center justify-center h-full text-center">
+		<div className="flex-1 flex flex-col gap-2 items-center justify-center h-full text-center max-w-md mx-auto">
 			{children}
 		</div>
 	);

--- a/frontend/src/components/actors/actors-list.tsx
+++ b/frontend/src/components/actors/actors-list.tsx
@@ -21,14 +21,13 @@ import {
 	FilterCreator,
 	FiltersDisplay,
 	type OnFiltersChange,
-	type PickFiltersOptions,
 	ScrollArea,
 	ShimmerLine,
 	SmallText,
 	WithTooltip,
 } from "@/components";
 import { VisibilitySensor } from "../visibility-sensor";
-import { useActorsFilters } from "./actor-filters-context";
+import { useActorsFilters, useFiltersValue } from "./actor-filters-context";
 import { useActorsLayout } from "./actors-layout-context";
 import { ActorsListRow, ActorsListRowSkeleton } from "./actors-list-row";
 import { useActorsView } from "./actors-view-context-provider";
@@ -198,14 +197,6 @@ export function ListSkeleton() {
 				))}
 		</div>
 	);
-}
-
-function useFiltersValue(opts: PickFiltersOptions = {}) {
-	const { pick } = useActorsFilters();
-	return useSearch({
-		from: "/_layout",
-		select: (state) => pick(state, opts),
-	});
 }
 
 function EmptyState({ count }: { count: number }) {

--- a/frontend/src/components/actors/guard-connectable-inspector.tsx
+++ b/frontend/src/components/actors/guard-connectable-inspector.tsx
@@ -1,0 +1,219 @@
+import { faPowerOff, faSpinnerThird, Icon } from "@rivet-gg/icons";
+import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useMatch } from "@tanstack/react-router";
+import { type ReactNode, useMemo } from "react";
+import { useInspectorCredentials } from "@/app/credentials-context";
+import { createEngineActorContext } from "@/queries/actor-engine";
+import { createInspectorActorContext } from "@/queries/actor-inspector";
+import {
+	type NamespaceNameId,
+	runnerByNameQueryOptions,
+} from "@/queries/manager-engine";
+import { DiscreteCopyButton } from "../copy-area";
+import { Button } from "../ui/button";
+import { useFiltersValue } from "./actor-filters-context";
+import { ActorProvider } from "./actor-queries-context";
+import { Info } from "./actor-state-tab";
+import { useManager } from "./manager-context";
+import type { ActorId } from "./queries";
+
+interface GuardConnectableInspectorProps {
+	actorId: ActorId;
+	children: ReactNode;
+}
+
+export function GuardConnectableInspector({
+	actorId,
+	children,
+}: GuardConnectableInspectorProps) {
+	const filters = useFiltersValue({ includeEphemeral: true });
+	const {
+		data: { destroyedAt, sleepingAt, pendingAllocationAt, startedAt } = {},
+	} = useQuery({
+		...useManager().actorQueryOptions(actorId),
+		refetchInterval: 1000,
+	});
+
+	if (destroyedAt) {
+		return <Info>Unavailable for inactive Actors.</Info>;
+	}
+
+	if (sleepingAt) {
+		if (filters.wakeOnSelect?.value?.[0] === "1") {
+			return (
+				<Info>
+					<AutoWakeUpActor actorId={actorId} />
+				</Info>
+			);
+		}
+		return (
+			<Info>
+				<p>Unavailable for sleeping Actors.</p>
+				<WakeUpActorButton actorId={actorId} />
+			</Info>
+		);
+	}
+
+	if (pendingAllocationAt && !startedAt) {
+		return (
+			<Info>
+				Cannot start Actor, runners are out of capacity. Add more
+				runners to run the Actor or increase runner capacity.
+			</Info>
+		);
+	}
+
+	return (
+		<ActorContextProvider actorId={actorId}>
+			{children}
+		</ActorContextProvider>
+	);
+}
+
+function ActorContextProvider(props: {
+	actorId: ActorId;
+	children: ReactNode;
+}) {
+	return __APP_TYPE__ === "inspector" ? (
+		<ActorInspectorProvider {...props} />
+	) : (
+		<ActorEngineProvider {...props} />
+	);
+}
+
+function ActorInspectorProvider({
+	actorId,
+	children,
+}: {
+	actorId: ActorId;
+	children: ReactNode;
+}) {
+	const { data } = useSuspenseQuery(useManager().actorQueryOptions(actorId));
+	const { credentials } = useInspectorCredentials();
+
+	if (!credentials?.url || !credentials?.token) {
+		throw new Error("Missing inspector credentials");
+	}
+
+	const actorContext = useMemo(() => {
+		return createInspectorActorContext({
+			...credentials,
+			name: data.name || "",
+		});
+	}, [credentials, data.name]);
+
+	return <ActorProvider value={actorContext}>{children}</ActorProvider>;
+}
+
+function useActorRunner({ actorId }: { actorId: ActorId }) {
+	const { data: actor } = useSuspenseQuery(
+		useManager().actorQueryOptions(actorId),
+	);
+
+	const match = useMatch({
+		from: "/_layout/ns/$namespace",
+	});
+
+	if (!match.params.namespace || !actor.runner) {
+		throw new Error("Actor is missing required fields");
+	}
+
+	const { data: runner } = useQuery({
+		...runnerByNameQueryOptions({
+			runnerName: actor.runner,
+			namespace: match.params.namespace as NamespaceNameId,
+		}),
+		refetchInterval: 1000,
+	});
+
+	return { actor, runner };
+}
+
+function useActorEngineContext({ actorId }: { actorId: ActorId }) {
+	const { actor, runner } = useActorRunner({ actorId });
+
+	const actorContext = useMemo(() => {
+		return createEngineActorContext({
+			token: (runner?.metadata?.inspectorToken as string) || "",
+		});
+	}, [runner?.metadata?.inspectorToken]);
+
+	return { actorContext, actor, runner };
+}
+
+function ActorEngineProvider({
+	actorId,
+	children,
+}: {
+	actorId: ActorId;
+	children: ReactNode;
+}) {
+	const { actorContext, actor, runner } = useActorEngineContext({ actorId });
+
+	if (!runner || !actor.runner) {
+		return (
+			<NoRunnerInfo runner={runner?.name || actor.runner || "unknown"} />
+		);
+	}
+
+	return <ActorProvider value={actorContext}>{children}</ActorProvider>;
+}
+
+function NoRunnerInfo({ runner }: { runner: string }) {
+	return (
+		<Info>
+			<p>There are no runners connected to run this Actor.</p>
+			<p>
+				Check that your application is running and the
+				runner&nbsp;name&nbsp;is&nbsp;
+				<DiscreteCopyButton
+					value={runner || ""}
+					className="inline-block p-0 h-auto px-0.5 -mx-0.5"
+				>
+					<span className="font-mono-console">{runner}</span>
+				</DiscreteCopyButton>
+			</p>
+		</Info>
+	);
+}
+
+function WakeUpActorButton({ actorId }: { actorId: ActorId }) {
+	const { runner, actorContext } = useActorEngineContext({ actorId });
+
+	const { mutate, isPending } = useMutation(
+		actorContext.actorWakeUpMutationOptions(actorId),
+	);
+	if (!runner) return null;
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={() => mutate()}
+			isLoading={isPending}
+			startIcon={<Icon icon={faPowerOff} />}
+		>
+			Wake up Actor
+		</Button>
+	);
+}
+
+function AutoWakeUpActor({ actorId }: { actorId: ActorId }) {
+	const { runner, actor, actorContext } = useActorEngineContext({ actorId });
+
+	const { isPending } = useQuery(
+		actorContext.actorAutoWakeUpQueryOptions(actorId, {
+			enabled: !!runner,
+		}),
+	);
+
+	if (!runner) return <NoRunnerInfo runner={actor.runner || "unknown"} />;
+
+	return isPending ? (
+		<Info>
+			<div className="flex items-center">
+				<Icon icon={faSpinnerThird} className="animate-spin mr-2" />
+				Waiting for Actor to wake...
+			</div>
+		</Info>
+	) : null;
+}

--- a/frontend/src/queries/manager-engine.ts
+++ b/frontend/src/queries/manager-engine.ts
@@ -281,6 +281,28 @@ export const runnerQueryOptions = (opts: {
 	});
 };
 
+export const runnerByNameQueryOptions = (opts: {
+	namespace: NamespaceNameId;
+	runnerName: string;
+}) => {
+	return queryOptions({
+		queryKey: [opts.namespace, "runner", opts.runnerName],
+		enabled: !!opts.runnerName,
+		queryFn: async ({ signal: abortSignal }) => {
+			const data = await client.runners.list(
+				{ namespace: opts.namespace, name: opts.runnerName },
+				{
+					abortSignal,
+				},
+			);
+			if (!data.runners[0]) {
+				throw new Error("Runner not found");
+			}
+			return data.runners[0];
+		},
+	});
+};
+
 export const runnerNamesQueryOptions = (opts: {
 	namespace: NamespaceNameId;
 }) => {


### PR DESCRIPTION
Closes FRONT-796

### TL;DR

Added auto-wake functionality for sleeping actors in the actor inspector UI.

### What changed?

- Added a new `wakeOnSelect` filter option that automatically wakes up sleeping actors when selected
- Created a `GuardConnectableInspector` component that handles different actor states (destroyed, sleeping, pending allocation)
- Implemented actor wake-up functionality with both manual and automatic options
- Added mutation and query options for waking up actors
- Improved error handling and user feedback for various actor states
- Refactored the actor context provider system to better handle different actor states
- Enhanced filter definitions to support default values

### How to test?

1. Select a sleeping actor in the actors list
2. Observe that it automatically wakes up if the "Auto-wake Actors on select" filter is enabled
3. Disable the auto-wake filter and select a sleeping actor
4. Verify that a "Wake up Actor" button appears and functions correctly
5. Test different actor states (destroyed, sleeping, pending allocation) to ensure appropriate messages are displayed

### Why make this change?

This change improves the user experience when working with sleeping actors by providing an automatic wake-up option. Previously, users had to manually wake up actors before being able to inspect them, which added friction to the workflow. The new functionality streamlines the process while still giving users control over when actors are awakened.