### PR TITLE
fix(fe): links in new window

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,10 +1,8 @@
 import {
 	faArrowUpRight,
-	faCheck,
 	faLink,
 	faServer,
 	faSpinnerThird,
-	faTriangleExclamation,
 	Icon,
 } from "@rivet-gg/icons";
 import { useQuery } from "@tanstack/react-query";
@@ -197,7 +195,13 @@ const Sidebar = ({
 									/>
 								}
 							>
-								<a href="http://rivet.gg/discord">Discord</a>
+								<a
+									href="http://rivet.gg/discord"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Discord
+								</a>
 							</Button>
 							<Button
 								variant="ghost"
@@ -210,7 +214,11 @@ const Sidebar = ({
 									/>
 								}
 							>
-								<a href="http://github.com/rivet-gg/rivet">
+								<a
+									href="http://github.com/rivet-gg/rivet"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
 									GitHub
 								</a>
 							</Button>


### PR DESCRIPTION
### TL;DR

Added `target="_blank"` and `rel="noopener noreferrer"` to Discord and GitHub links in the sidebar.

### What changed?

- Removed unused icon imports (`faCheck` and `faTriangleExclamation`)
- Added `target="_blank"` and `rel="noopener noreferrer"` attributes to the Discord and GitHub links in the sidebar to ensure they open in new tabs

### How to test?

1. Navigate to any page with the sidebar
2. Click on either the Discord or GitHub links
3. Verify that they open in a new tab instead of replacing the current page

### Why make this change?

This improves user experience by allowing users to visit external resources without losing their current context in the application. The `rel="noopener noreferrer"` attribute also adds security by preventing the new tab from accessing the window.opener property.