### PR TITLE
Remove 404 from  self-hosting docs

### DIFF
--- a/site/src/content/docs/self-hosting/index.mdx
+++ b/site/src/content/docs/self-hosting/index.mdx
@@ -28,17 +28,17 @@ Rivet supports multiple storage backends:
 
 Deploy Rivet on your preferred platform:
 
-- [Docker Container](./docker-container)
-- [Docker Compose](./docker-compose)
-- [Kubernetes](./kubernetes)
-- [AWS Fargate](./aws-fargate)
-- [Google Cloud Run](./google-cloud-run)
-- [Hetzner](./hetzner)
-- [Railway](./railway)
+- [Docker Container](./docker-container.mdx)
+- [Docker Compose](./docker-compose.mdx)
+- [Kubernetes](./kubernetes.mdx)
+- [AWS Fargate](./aws-fargate.mdx)
+- [Google Cloud Run](./google-cloud-run.mdx)
+- [Hetzner](./hetzner.mdx)
+- [Railway](./railway.mdx)
 
 ## Next Steps
 
-- [Install Rivet Engine](./install)
-- [Connect your backend](./connect-backend)
-- [Configure your deployment](./configuration)
-- [Multi-region setup](./multi-region)
+- [Install Rivet Engine](./install.mdx)
+- [Connect your backend](./connect-backend.mdx)
+- [Configure your deployment](./configuration.mdx)
+- [Multi-region setup](./multi-region.mdx)


### PR DESCRIPTION
Hi  stumbled onto this project and discovered that some parts of the docs  were leading to 404
https://www.rivet.dev/docs/self-hosting 
<img width="508" height="537" alt="image" src="https://github.com/user-attachments/assets/08af7f4e-0456-41e2-a753-8e596f28e891" />
