### PR TITLE
feat: add datacenter field to runners table

### DIFF
--- a/frontend/src/app/runners-table.tsx
+++ b/frontend/src/app/runners-table.tsx
@@ -37,6 +37,7 @@ export function RunnersTable({
 					<TableHead />
 					<TableHead>ID</TableHead>
 					<TableHead>Name</TableHead>
+					<TableHead>Datacenter</TableHead>
 					<TableHead>Slots</TableHead>
 					<TableHead>Last ping</TableHead>
 					<TableHead>Created</TableHead>
@@ -117,6 +118,9 @@ function RowSkeleton() {
 			<TableCell>
 				<Skeleton className="w-full h-4" />
 			</TableCell>
+			<TableCell>
+				<Skeleton className="w-full h-4" />
+			</TableCell>
 		</TableRow>
 	);
 }
@@ -142,6 +146,7 @@ function Row(runner: Rivet.Runner) {
 					{runner.name}
 				</DiscreteCopyButton>
 			</TableCell>
+			<TableCell>{runner.datacenter}</TableCell>
 
 			<TableCell>
 				{runner.remainingSlots}/{runner.totalSlots}


### PR DESCRIPTION
Closes FRONT-792

### TL;DR

Added a Datacenter column to the Runners Table to display runner datacenter information.

### What changed?

- Added a new "Datacenter" column header to the Runners Table
- Added a corresponding table cell in the RowSkeleton component to maintain proper layout when loading
- Added a table cell to display the runner's datacenter value in the Row component

### How to test?

1. Navigate to the Runners Table view
2. Verify that the "Datacenter" column appears between the "Name" and "Slots" columns
3. Confirm that each runner's datacenter information is correctly displayed in the new column
4. Check that the loading skeleton properly includes the new column

### Why make this change?

This change improves visibility of runner datacenter information, making it easier for users to identify where runners are located without having to drill down into individual runner details. This information is valuable for managing distributed runner deployments across multiple datacenters.