### PR TITLE
feat(cloud): runners

### DIFF
--- a/frontend/src/app/dialogs/connect-railway-frame.tsx
+++ b/frontend/src/app/dialogs/connect-railway-frame.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components";
 import { useEngineCompatDataProvider } from "@/components/actors";
 import { defineStepper } from "@/components/ui/stepper";
-import { engineEnv } from "@/lib/env";
+import { cloudEnv, engineEnv } from "@/lib/env";
 
 const { Stepper } = defineStepper(
 	{
@@ -58,6 +58,10 @@ export default function ConnectRailwayFrameContent({
 }
 
 function FormStepper({ onClose }: { onClose?: () => void }) {
+	const dataProvider = useEngineCompatDataProvider();
+
+	const { data } = useQuery(dataProvider.connectRunnerTokenQueryOptions());
+
 	return (
 		<Stepper.Provider variant="vertical">
 			{({ methods }) => (
@@ -86,7 +90,14 @@ function FormStepper({ onClose }: { onClose?: () => void }) {
 														quickly.
 													</p>
 													<a
-														href="https://railway.com/deploy/rivet?referralCode=RC7bza&utm_medium=integration&utm_source=template&utm_campaign=generic"
+														href={`https://railway.com/new/template/rivet-cloud-starter?referralCode=RC7bza&utm_medium=integration&utm_source=template&utm_campaign=generic&RIVET_TOKEN=${data}&RIVET_ENGINE=${
+															__APP_TYPE__ ===
+															"engine"
+																? engineEnv()
+																		.VITE_APP_API_URL
+																: cloudEnv()
+																		.VITE_APP_CLOUD_ENGINE_URL
+														}`}
 														target="_blank"
 														rel="noreferrer"
 														className="inline-block h-10"
@@ -156,7 +167,6 @@ function EnvVariablesStep() {
 	const { data, isLoading } = useQuery(
 		dataProvider.connectRunnerTokenQueryOptions(),
 	);
-
 	return (
 		<>
 			<p>

--- a/frontend/src/app/dialogs/edit-runner-config.tsx
+++ b/frontend/src/app/dialogs/edit-runner-config.tsx
@@ -1,0 +1,67 @@
+import { faQuestionCircle, faRailway, Icon } from "@rivet-gg/icons";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import * as EditRunnerConfigForm from "@/app/forms/edit-runner-config-form";
+import { HelpDropdown } from "@/app/help-dropdown";
+import { Button, type DialogContentProps, Frame } from "@/components";
+import { useEngineCompatDataProvider } from "@/components/actors";
+
+interface EditRunnerConfigFrameContentProps extends DialogContentProps {
+	name: string;
+}
+
+export default function EditRunnerConfigFrameContent({
+	name,
+	onClose,
+}: EditRunnerConfigFrameContentProps) {
+	const { data } = useSuspenseQuery({
+		...useEngineCompatDataProvider().runnerConfigQueryOptions(name),
+		refetchInterval: 5000,
+	});
+
+	return (
+		<EditRunnerConfigForm.Form
+			onSubmit={async () => {
+				onClose?.();
+			}}
+			defaultValues={{
+				url: data.serverless.url,
+				maxRunners: data.serverless.maxRunners,
+				minRunners: data.serverless.minRunners,
+				requestLifespan: data.serverless.requestLifespan,
+				runnersMargin: data.serverless.runnersMargin,
+				slotsPerRunner: data.serverless.slotsPerRunner,
+			}}
+		>
+			<Frame.Header>
+				<Frame.Title className="justify-between flex items-center">
+					<div>
+						Add <Icon icon={faRailway} className="ml-0.5" /> Railway
+					</div>
+					<HelpDropdown>
+						<Button variant="ghost" size="icon">
+							<Icon icon={faQuestionCircle} />
+						</Button>
+					</HelpDropdown>
+				</Frame.Title>
+			</Frame.Header>
+			<Frame.Content>
+				<EditRunnerConfigForm.Url />
+				<div className="grid grid-cols-2">
+					<EditRunnerConfigForm.MinRunners />
+					<EditRunnerConfigForm.MaxRunners />
+					<EditRunnerConfigForm.RunnersMargin />
+				</div>
+				<div className="grid grid-cols-2">
+					<EditRunnerConfigForm.RequestLifespan />
+					<EditRunnerConfigForm.RunnersMargin />
+				</div>
+				<EditRunnerConfigForm.SlotsPerRunner />
+				<div className="flex justify-end mt-4">
+					<EditRunnerConfigForm.Submit>
+						Save
+					</EditRunnerConfigForm.Submit>
+				</div>
+			</Frame.Content>
+		</EditRunnerConfigForm.Form>
+	);
+}

--- a/frontend/src/app/forms/edit-runner-config-form.tsx
+++ b/frontend/src/app/forms/edit-runner-config-form.tsx
@@ -1,0 +1,151 @@
+import { type UseFormReturn, useFormContext } from "react-hook-form";
+import z from "zod";
+import {
+	createSchemaForm,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	Input,
+} from "@/components";
+
+export const formSchema = z.object({
+	url: z.string().url(),
+	maxRunners: z.number().positive(),
+	minRunners: z.number().positive(),
+	requestLifespan: z.number().positive(),
+	runnersMargin: z.number().positive(),
+	slotsPerRunner: z.number().positive(),
+});
+
+export type FormValues = z.infer<typeof formSchema>;
+export type SubmitHandler = (
+	values: FormValues,
+	form: UseFormReturn<FormValues>,
+) => Promise<void>;
+
+const { Form, Submit, SetValue } = createSchemaForm(formSchema);
+export { Form, Submit, SetValue };
+
+export const Url = ({ className }: { className?: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="url"
+			render={({ field }) => (
+				<FormItem className={className}>
+					<FormLabel className="col-span-1">Url</FormLabel>
+					<FormControl className="row-start-2">
+						<Input
+							placeholder="https://your-rivet-runner"
+							maxLength={25}
+							{...field}
+						/>
+					</FormControl>
+					<FormMessage className="col-span-1" />
+				</FormItem>
+			)}
+		/>
+	);
+};
+
+export const MinRunners = ({ className }: { className?: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="url"
+			render={({ field }) => (
+				<FormItem className={className}>
+					<FormLabel className="col-span-1">Min Runners</FormLabel>
+					<FormControl className="row-start-2">
+						<Input type="number" {...field} />
+					</FormControl>
+					<FormMessage className="col-span-1" />
+				</FormItem>
+			)}
+		/>
+	);
+};
+
+export const MaxRunners = ({ className }: { className?: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="maxRunners"
+			render={({ field }) => (
+				<FormItem className={className}>
+					<FormLabel className="col-span-1">Max Runners</FormLabel>
+					<FormControl className="row-start-2">
+						<Input type="number" {...field} />
+					</FormControl>
+					<FormMessage className="col-span-1" />
+				</FormItem>
+			)}
+		/>
+	);
+};
+
+export const RequestLifespan = ({ className }: { className?: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="requestLifespan"
+			render={({ field }) => (
+				<FormItem className={className}>
+					<FormLabel className="col-span-1">
+						Request Lifespan
+					</FormLabel>
+					<FormControl className="row-start-2">
+						<Input type="number" {...field} />
+					</FormControl>
+					<FormMessage className="col-span-1" />
+				</FormItem>
+			)}
+		/>
+	);
+};
+
+export const RunnersMargin = ({ className }: { className?: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="runnersMargin"
+			render={({ field }) => (
+				<FormItem className={className}>
+					<FormLabel className="col-span-1">Runners Margin</FormLabel>
+					<FormControl className="row-start-2">
+						<Input type="number" {...field} />
+					</FormControl>
+					<FormMessage className="col-span-1" />
+				</FormItem>
+			)}
+		/>
+	);
+};
+
+export const SlotsPerRunner = ({ className }: { className?: string }) => {
+	const { control } = useFormContext<FormValues>();
+	return (
+		<FormField
+			control={control}
+			name="slotsPerRunner"
+			render={({ field }) => (
+				<FormItem className={className}>
+					<FormLabel className="col-span-1">
+						Slots Per Runner
+					</FormLabel>
+					<FormControl className="row-start-2">
+						<Input type="number" {...field} />
+					</FormControl>
+					<FormMessage className="col-span-1" />
+				</FormItem>
+			)}
+		/>
+	);
+};

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace/connect.tsx
@@ -4,11 +4,23 @@ import {
 	createFileRoute,
 	notFound,
 	Link as RouterLink,
+	useNavigate,
 } from "@tanstack/react-router";
 import { match } from "ts-pattern";
 import { HelpDropdown } from "@/app/help-dropdown";
 import { RunnersTable } from "@/app/runners-table";
-import { Button, DocsSheet, H1, H3, Link, Skeleton } from "@/components";
+import {
+	Button,
+	DocsSheet,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	H1,
+	H3,
+	Link,
+	Skeleton,
+} from "@/components";
 import { useEngineCompatDataProvider } from "@/components/actors";
 import { docsLinks } from "@/content/data";
 
@@ -23,9 +35,9 @@ export const Route = createFileRoute(
 });
 
 export function RouteComponent() {
-	const { data: configsCount, isLoading } = useInfiniteQuery({
-		...useEngineCompatDataProvider().runnerConfigsQueryOptions(),
-		select: (data) => Object.values(data.pages[0].runnerConfigs).length,
+	const { data: runnerNamesCount, isLoading } = useInfiniteQuery({
+		...useEngineCompatDataProvider().runnerNamesQueryOptions(),
+		select: (data) => data.pages[0].names?.length,
 	});
 
 	return (
@@ -63,7 +75,7 @@ export function RouteComponent() {
 						<Skeleton className="min-w-48 h-auto min-h-28 rounded-md" />
 					</div>
 				</div>
-			) : configsCount === 0 ? (
+			) : runnerNamesCount !== 0 ? (
 				<div className="p-4 px-6 max-w-5xl">
 					<H3>Select Provider</H3>
 					<div className="flex flex-wrap gap-2 my-4">
@@ -113,6 +125,8 @@ function Providers() {
 		refetchInterval: 5000,
 	});
 
+	const navigate = Route.useNavigate();
+
 	return (
 		<div className="p-4 px-6 max-w-5xl">
 			<H3>Providers</H3>
@@ -136,6 +150,39 @@ function Providers() {
 						</RouterLink>
 					</Button>
 				))}
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							size="lg"
+							className="min-w-32"
+							variant="outline"
+						></Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent>
+						<DropdownMenuItem
+							indicator={<Icon icon={faRailway} />}
+							onSelect={() => {
+								navigate({
+									to: ".",
+									search: { modal: "connect-railway" },
+								});
+							}}
+						>
+							Railway
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							indicator={<Icon icon={faVercel} />}
+							onSelect={() => {
+								navigate({
+									to: ".",
+									search: { modal: "connect-vercel" },
+								});
+							}}
+						>
+							Vercel
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
### TL;DR

Added Railway integration with automatic token passing and created a runner configuration editor.

### What changed?

- Updated the Railway integration to automatically pass the Rivet token and engine URL to Railway when deploying
- Added a new `runnerConfigQueryOptions` function to fetch runner configuration data
- Created a new edit runner config dialog and form components to allow editing runner configurations
- Fixed the `runnerNamesQueryOptions` function to use the namespace from context instead of requiring it as a parameter
- Added a dropdown menu for selecting providers in the connect page

### How to test?

1. Navigate to the namespace connect page
2. Click on the Railway option in the providers dropdown
3. Verify that the Railway deployment link includes the Rivet token and engine URL
4. Test the runner configuration editor by selecting a runner and editing its configuration

### Why make this change?

This change improves the Railway integration experience by automatically passing necessary credentials, eliminating manual configuration steps. It also adds the ability to edit runner configurations directly from the UI, giving users more control over their runner settings without having to use the API directly.