### PR TITLE
fix: inspector

### DIFF
--- a/frontend/src/components/actors/actor-queries-context.tsx
+++ b/frontend/src/components/actors/actor-queries-context.tsx
@@ -5,7 +5,9 @@ import type { ActorId } from "./queries";
 
 type RequestOptions = Parameters<typeof createActorInspectorClient>[1];
 
-export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
+export const createDefaultActorContext = (
+	{ hash }: { hash: string } = { hash: `${Date.now()}` },
+) => ({
 	createActorInspectorFetchConfiguration: (
 		actorId: ActorId | string,
 	): RequestOptions => ({
@@ -33,7 +35,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 			refetchInterval: 1000,
 			...opts,
 			queryKey: [hash, "actor", actorId, "ping"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.ping.$get();
 				if (!response.ok) {
@@ -52,7 +54,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 			enabled,
 			refetchInterval: 1000,
 			queryKey: [hash, "actor", actorId, "state"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.state.$get();
 
@@ -75,7 +77,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 			enabled,
 			refetchInterval: 1000,
 			queryKey: [hash, "actor", actorId, "connections"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.connections.$get();
 
@@ -94,7 +96,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 		return queryOptions({
 			enabled,
 			queryKey: [hash, "actor", actorId, "database"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.db.$get();
 
@@ -143,7 +145,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 			staleTime: 0,
 			gcTime: 5000,
 			queryKey: [hash, "actor", actorId, "database", table],
-			queryFn: async ({ queryKey: [, actorId, , table] }) => {
+			queryFn: async ({ queryKey: [, , actorId, , table] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.db.$post({
 					json: { query: `SELECT * FROM ${table} LIMIT 500` },
@@ -164,7 +166,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 			enabled,
 			refetchInterval: 1000,
 			queryKey: [hash, "actor", actorId, "events"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.events.$get();
 
@@ -183,7 +185,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 		return queryOptions({
 			enabled,
 			queryKey: [hash, "actor", actorId, "rpcs"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				const response = await client.rpcs.$get();
 
@@ -234,7 +236,7 @@ export const createDefaultActorContext = ({ hash }: { hash: string } = {}) => ({
 			staleTime: 0,
 			gcTime: 0,
 			queryKey: [hash, "actor", actorId, "auto-wake-up"],
-			queryFn: async ({ queryKey: [, actorId] }) => {
+			queryFn: async ({ queryKey: [, , actorId] }) => {
 				const client = this.createActorInspector(actorId);
 				try {
 					await client.ping.$get();


### PR DESCRIPTION
### TL;DR

Fixed query key indexing in actor queries context and added default timestamp-based hash generation.

### What changed?

- Fixed the `queryFn` implementations to correctly access the `actorId` from the query key array at index 2 instead of index 1
- Added a default value for the `hash` parameter that uses the current timestamp (`Date.now()`) when no hash is provided

### How to test?

1. Verify that actor queries work correctly by navigating to the actor inspector in the UI
2. Test with both explicit hash values and without providing a hash to ensure the default timestamp-based hash works properly
3. Confirm that all actor-related queries (ping, state, connections, database, events, RPCs, auto-wake-up) function as expected

### Why make this change?

The previous implementation had incorrect indexing when accessing query key elements, which could lead to undefined values and errors. The query key structure is `[hash, "actor", actorId, ...]`, so the `actorId` is at index 2, not index 1. Additionally, providing a default timestamp-based hash ensures that the context always has a unique identifier even when not explicitly provided.